### PR TITLE
Enable SMTP-based email verification flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,20 @@ npm run dev
 ## Prefill из URL
 - `?asset=ton&to=EQ...&amount=1.2&comment=Coffee`
 - `?asset=jetton&jetton=kQ...&to=EQ...&amount=5&comment=tip`
+
+## SMTP для подтверждения e-mail
+Для отправки кода подтверждения по почте настрой переменные окружения (см. `.env.local`):
+
+```
+EMAIL_FROM="LocalBali <no-reply@example.com>"
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=api@example.com
+SMTP_PASS=super-secret
+# опционально:
+# SMTP_SECURE=true
+# или единая строка подключения:
+# EMAIL_TRANSPORT_URL="smtps://user:pass@smtp.example.com:465"
+```
+
+API `POST /api/email/send-code` использует эти значения и отправляет код подтверждения на указанный адрес.

--- a/app/api/email/send-code/route.ts
+++ b/app/api/email/send-code/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateEmailFormat } from '../../../../lib/email-util';
+import { sendVerificationEmail, EmailConfigError } from '../../../../lib/server/email-sender';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest){
+  try {
+    const body = await request.json().catch(()=>null) as { email?: string; code?: string; locale?: string } | null;
+    const email = body?.email?.trim();
+    const code = body?.code?.trim();
+    const locale = body?.locale;
+
+    if(!email || !code){
+      return NextResponse.json({ error: 'E-mail и код обязательны' }, { status: 400 });
+    }
+    if(!validateEmailFormat(email)){
+      return NextResponse.json({ error: 'Некорректный e-mail' }, { status: 400 });
+    }
+    if(!/^\d{6}$/.test(code)){
+      return NextResponse.json({ error: 'Некорректный код подтверждения' }, { status: 400 });
+    }
+
+    await sendVerificationEmail({ email, code, locale });
+
+    return NextResponse.json({ ok: true });
+  } catch (err: unknown) {
+    console.error('[email:send-code]', err);
+    const status = err instanceof EmailConfigError ? 500 : 502;
+    const fallback = status === 500
+      ? 'Почтовый сервис не настроен. Обратитесь к администратору.'
+      : 'Не удалось отправить письмо. Попробуйте позже.';
+    const message = err instanceof EmailConfigError
+      ? fallback
+      : err instanceof Error && err.message ? err.message : fallback;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/app/email/page.tsx
+++ b/app/email/page.tsx
@@ -4,13 +4,13 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   validateEmailFormat, suggestDomainFor, isDisposableDomain,
-  startVerification, verifyCode, getEmail, splitEmail
+  startVerification, verifyCode, getEmail, splitEmail, clearVerificationSession
 } from '../../lib/email-util';
 
 export default function EmailPage(){
   const router = useRouter();
-  const [{email, sent, demoCode, error, info, code}, set] = useState({
-    email:'', sent:false, demoCode:'', error:'', info:'', code:''
+  const [{email, sent, sending, error, info, code}, set] = useState({
+    email:'', sent:false, sending:false, error:'', info:'', code:''
   });
 
   useEffect(()=>{
@@ -27,17 +27,41 @@ export default function EmailPage(){
     return domain ? isDisposableDomain(domain) : false;
   }, [email]);
 
-  const onSend = ()=>{
+  const sendCode = async ()=>{
     const e = email.trim();
     if(!validateEmailFormat(e)){
       set(s=>({...s, error:'Введите корректный e-mail', info:''}));
       return;
     }
-    const {code} = startVerification(e, 600);
-    set(s=>({...s, sent:true, demoCode:code, error:'', info:'Код отправлен (демо). Введите 6 цифр ниже.'}));
+
+    set(s=>({...s, sending:true, error:'', info:''}));
+    const { code: generated } = startVerification(e, 600);
+
+    try {
+      const locale = typeof navigator !== 'undefined' ? navigator.language : undefined;
+      const res = await fetch('/api/email/send-code', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: e, code: generated, locale }),
+      });
+
+      if(!res.ok){
+        const data = await res.json().catch(()=>null);
+        throw new Error(data?.error || 'Не удалось отправить код. Попробуйте позже.');
+      }
+
+      set(s=>({...s, sent:true, sending:false, code:'', error:'', info:'Код отправлен. Проверьте почту (включая спам).'}));
+    } catch (err: unknown) {
+      clearVerificationSession();
+      const message = err instanceof Error ? err.message : 'Не удалось отправить код. Попробуйте позже.';
+      set(s=>({...s, sent:false, sending:false, info:'', error: message }));
+    }
   };
 
+  const onSend = ()=>{ void sendCode(); };
+
   const onVerify = ()=>{
+    set(s=>({...s, error:'', info:''}));
     const res = verifyCode(code);
     if(!res.ok){
       const map: Record<string,string> = {
@@ -52,7 +76,7 @@ export default function EmailPage(){
     router.push('/profile' as any);
   };
 
-  const onResend = ()=> onSend();
+  const onResend = ()=>{ void sendCode(); };
 
   return (
     <div className="vstack" style={{gap:16}}>
@@ -96,7 +120,9 @@ export default function EmailPage(){
         )}
 
         {!sent ? (
-          <button className="btn primary" onClick={onSend}>Отправить код</button>
+          <button className="btn primary" onClick={onSend} disabled={sending}>
+            {sending ? 'Отправляем…' : 'Отправить код'}
+          </button>
         ) : (
           <div className="vstack" style={{gap:8}}>
             <label htmlFor="code"><b>Код из письма</b></label>
@@ -107,11 +133,12 @@ export default function EmailPage(){
                       letterSpacing:'6px', textAlign:'center', fontSize:18}}
             />
             <div className="hstack" style={{justifyContent:'space-between'}}>
-              <button className="btn" onClick={onResend}>Отправить ещё раз</button>
-              <button className="btn primary" onClick={onVerify}>Подтвердить</button>
-            </div>
-            <div className="muted" style={{fontSize:12}}>
-              Для демо: код <b>{demoCode}</b> (в реальном приложении он придёт письмом).
+              <button className="btn" onClick={onResend} disabled={sending}>
+                {sending ? 'Отправляем…' : 'Отправить ещё раз'}
+              </button>
+              <button className="btn primary" onClick={onVerify} disabled={code.length !== 6}>
+                Подтвердить
+              </button>
             </div>
           </div>
         )}
@@ -121,7 +148,7 @@ export default function EmailPage(){
       </div>
 
       <div className="card muted" style={{fontSize:12}}>
-        Без бэкенда e-mail подтверждается локально. Для реальной отправки писем нужен сервер/SMTP.
+        Письмо отправляется через настроенный SMTP (см. README). Код хранится локально до подтверждения.
       </div>
     </div>
   );

--- a/lib/email-util.ts
+++ b/lib/email-util.ts
@@ -69,8 +69,13 @@ export function startVerification(email: string, ttlSeconds=600): {code:string, 
   localStorage.setItem(LS.pending, email.trim());
   localStorage.setItem(LS.code, code);
   localStorage.setItem(LS.exp, String(exp));
-  // В реале код отправили бы письмом. В демо вернём его наружу.
   return { code, exp };
+}
+
+export function clearVerificationSession(): void {
+  localStorage.removeItem(LS.pending);
+  localStorage.removeItem(LS.code);
+  localStorage.removeItem(LS.exp);
 }
 
 export function verifyCode(input: string): { ok:boolean; reason?:string } {

--- a/lib/server/email-sender.ts
+++ b/lib/server/email-sender.ts
@@ -1,0 +1,111 @@
+import nodemailer from 'nodemailer';
+
+type Locale = 'ru' | 'en' | 'id';
+
+type VerificationEmailOptions = {
+  email: string;
+  code: string;
+  locale?: string;
+};
+
+export class EmailConfigError extends Error {
+  constructor(message: string){
+    super(message);
+    this.name = 'EmailConfigError';
+  }
+}
+
+let cachedTransporter: nodemailer.Transporter | null = null;
+
+function resolveLocale(locale?: string): Locale {
+  if (!locale) return 'ru';
+  const normalized = locale.toLowerCase().split('-')[0] as Locale;
+  return normalized === 'en' || normalized === 'id' ? normalized : 'ru';
+}
+
+function ensureTransporter(): nodemailer.Transporter {
+  if (cachedTransporter) return cachedTransporter;
+
+  const transportUrl = process.env.EMAIL_TRANSPORT_URL;
+  if (transportUrl){
+    cachedTransporter = nodemailer.createTransport(transportUrl);
+    return cachedTransporter;
+  }
+
+  const host = process.env.SMTP_HOST;
+  if (!host){
+    throw new EmailConfigError('SMTP_HOST is not configured');
+  }
+  const parsedPort = process.env.SMTP_PORT ? Number(process.env.SMTP_PORT) : 587;
+  const port = Number.isFinite(parsedPort) && parsedPort > 0 ? parsedPort : 587;
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+  const secure = typeof process.env.SMTP_SECURE === 'string'
+    ? ['1', 'true', 'yes'].includes(process.env.SMTP_SECURE.toLowerCase())
+    : port === 465;
+
+  cachedTransporter = nodemailer.createTransport({
+    host,
+    port,
+    secure,
+    auth: user && pass ? { user, pass } : undefined,
+  });
+
+  return cachedTransporter;
+}
+
+function getCopy(code: string, locale?: string): { subject: string; text: string; html: string } {
+  const loc = resolveLocale(locale);
+  const map: Record<Locale, { subject: string; intro: string; outro: string }> = {
+    ru: {
+      subject: 'Код подтверждения LocalBali',
+      intro: 'Используйте этот код, чтобы подтвердить свой e-mail в LocalBali.',
+      outro: 'Код действует 10 минут. Если вы не запрашивали его, просто игнорируйте письмо.',
+    },
+    en: {
+      subject: 'LocalBali verification code',
+      intro: 'Use this code to confirm your e-mail address in LocalBali.',
+      outro: 'The code is valid for 10 minutes. If you did not request it, you can ignore this email.',
+    },
+    id: {
+      subject: 'Kode verifikasi LocalBali',
+      intro: 'Gunakan kode ini untuk mengonfirmasi e-mail Anda di LocalBali.',
+      outro: 'Kode berlaku selama 10 menit. Jika Anda tidak memintanya, abaikan email ini.',
+    },
+  };
+
+  const { subject, intro, outro } = map[loc];
+  const text = `${intro}\n\n${code}\n\n${outro}`;
+  const html = `
+    <div style="font-family:Arial,sans-serif;font-size:15px;line-height:1.4;color:#111">
+      <p>${intro}</p>
+      <div style="display:inline-block;padding:12px 18px;margin:12px 0;font-size:22px;font-weight:600;letter-spacing:4px;background:#f4f4f4;border-radius:8px;">${code}</div>
+      <p>${outro}</p>
+      <p style="margin-top:24px;font-size:12px;color:#666">LocalBali Security</p>
+    </div>
+  `;
+
+  return { subject, text, html };
+}
+
+export async function sendVerificationEmail({ email, code, locale }: VerificationEmailOptions): Promise<void> {
+  if (!email) throw new Error('Recipient email is required');
+  if (!code) throw new Error('Verification code is required');
+
+  const from = process.env.EMAIL_FROM;
+  if (!from){
+    throw new EmailConfigError('EMAIL_FROM is not configured');
+  }
+
+  const transporter = ensureTransporter();
+  const { subject, text, html } = getCopy(code, locale);
+
+  await transporter.sendMail({
+    from,
+    to: email,
+    subject,
+    text,
+    html,
+  });
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "html5-qrcode": "^2.3.8",
         "next": "^15.5.2",
         "next-themes": "^0.4.6",
+        "nodemailer": "^7.0.6",
         "qrcode": "^1.5.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -8579,6 +8580,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.3.tgz",
       "integrity": "sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog=="
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.6.tgz",
+      "integrity": "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "html5-qrcode": "^2.3.8",
     "next": "^15.5.2",
     "next-themes": "^0.4.6",
+    "nodemailer": "^7.0.6",
     "qrcode": "^1.5.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- add a reusable SMTP mailer based on nodemailer and expose an API route to send verification codes
- update the e-mail confirmation screen to call the API, handle resend states, and drop demo-only messaging
- document required SMTP environment variables for the new flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0489265883268943e791003d7ad6