### PR TITLE
Use typed Next.js Link in profile rows

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useEffect, useState } from 'react';
+import Link, { type LinkProps } from 'next/link';
 import { tr } from '../../components/ui/tr';
 
 export default function ProfilePage(){
@@ -95,14 +96,14 @@ export default function ProfilePage(){
   );
 }
 
-function Row({href, icon, label, value}:{href:string; icon:React.ReactNode; label:string; value?:string}){
+function Row({href, icon, label, value}:{href:LinkProps['href']; icon:React.ReactNode; label:string; value?:string}){
   return (
-    <a href={href as any} className="list-row">
+    <Link href={href} className="list-row">
       <span className="row-ico">{icon}</span>
       <span className="row-label">{label}</span>
       {value && <span className="row-value">{value}</span>}
       <span className="chev">›</span>
-    </a>
+    </Link>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace the profile page row anchor with Next.js Link and type-safe hrefs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cf12d7723083268727e2ca8bdf753f