### PR TITLE
Stabilize i18n provider translation function

### DIFF
--- a/components/providers/I18nProvider.tsx
+++ b/components/providers/I18nProvider.tsx
@@ -1,5 +1,5 @@
 'use client';
-import {createContext, useContext, useEffect, useMemo, useState} from 'react';
+import {createContext, useContext, useEffect, useMemo, useState, useCallback} from 'react';
 
 export type Lang = 'ru'|'en'|'id'|'es'|'de';
 
@@ -21,8 +21,8 @@ export default function I18nProvider({children}:{children:React.ReactNode}) {
   useEffect(() => {
     try { const s = localStorage.getItem('lang') as Lang | null; if (s) setLang(s); } catch {}
   }, []);
-  const t = (k:string) => (DICT[lang]?.[k] ?? k);
-  const value = useMemo(()=>({lang, setLang, t}),[lang]);
+  const t = useCallback((k:string) => (DICT[lang]?.[k] ?? k), [lang]);
+  const value = useMemo(()=>({lang, setLang, t}),[lang, t]);
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
 }
 


### PR DESCRIPTION
## Summary
- wrap the i18n translation helper in `useCallback` so its identity only changes when the language changes
- include the translation helper in the memoized context value dependencies

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68cf17aba7fc8326a147eb7f5a97837d