### PR TITLE
Wrap I18n translator in useCallback

### DIFF
--- a/components/providers/I18nProvider.tsx
+++ b/components/providers/I18nProvider.tsx
@@ -1,5 +1,5 @@
 'use client';
-import {createContext, useContext, useEffect, useMemo, useState} from 'react';
+import {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
 
 export type Lang = 'ru'|'en'|'id'|'es'|'de';
 
@@ -21,8 +21,8 @@ export default function I18nProvider({children}:{children:React.ReactNode}) {
   useEffect(() => {
     try { const s = localStorage.getItem('lang') as Lang | null; if (s) setLang(s); } catch {}
   }, []);
-  const t = (k:string) => (DICT[lang]?.[k] ?? k);
-  const value = useMemo(()=>({lang, setLang, t}),[lang]);
+  const t = useCallback((k:string) => (DICT[lang]?.[k] ?? k), [lang]);
+  const value = useMemo(()=>({lang, setLang, t}),[lang, t]);
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
 }
 


### PR DESCRIPTION
## Summary
- wrap the I18n translator function in useCallback keyed on the selected language
- include the memoized translator in the context memo dependencies so consumers see updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1953fcd0832694ec5d09f1a0f212