### PR TITLE
feat: hydrate telegram profile data

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -480,7 +480,9 @@ header a,header button,.header a,.header button{ pointer-events:auto; }
 .home-hero{background:linear-gradient(180deg,#0EA5FF 0%,#2D6CF6 100%);color:#fff;padding:16px 16px 24px;border-bottom-left-radius:24px;border-bottom-right-radius:24px;box-shadow:0 6px 20px rgba(0,0,0,.12)}
 .hero-top{display:flex;align-items:center;justify-content:space-between}
 .user-chip{display:flex;align-items:center;gap:12px}
-.user-chip .ava{width:40px;height:40px;border-radius:50%;background:#ddd;overflow:hidden}
+.user-chip .ava{width:40px;height:40px;border-radius:50%;background:#ddd;overflow:hidden;display:flex;align-items:center;justify-content:center;font-weight:800;color:#0c1a2a}
+.user-chip .ava img{width:100%;height:100%;object-fit:cover;display:block}
+.user-chip .ava span{font-size:16px;letter-spacing:.4px}
 .success-pill{background:rgba(255,255,255,.22);backdrop-filter:blur(8px);border-radius:12px;padding:8px 10px;color:#E2FBEA;border:1px solid rgba(255,255,255,.28);font-weight:800}
 .badge-beta{background:rgba(255,255,255,.22);padding:6px 10px;border-radius:12px;font-weight:800;display:flex;align-items:center;gap:6px}
 .hero-balance{text-align:center;margin-top:10px}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 
+import { useTelegramUser } from '@/lib/useTelegramUser';
+
 /* ===== Иконки ===== */
 function IconPlus() {
   return (
@@ -64,15 +66,22 @@ function Action({
 
 export default function HomePage() {
   const [hide, setHide] = useState(false);
-  const [user, setUser] = useState('@mityya_La');
+  const { displayName, photoUrl, initials } = useTelegramUser();
+  const [userLabel, setUserLabel] = useState(displayName);
+  const [avatarUrl, setAvatarUrl] = useState(photoUrl);
+  const [avatarInitials, setAvatarInitials] = useState(initials);
 
   useEffect(() => {
     try {
       setHide(localStorage.getItem('hideBalance') === '1');
-      const u = localStorage.getItem('username') || '@mityya_La';
-      setUser(u.startsWith('@') ? u : '@' + u);
     } catch {}
   }, []);
+
+  useEffect(() => {
+    setUserLabel((prev) => (prev === displayName ? prev : displayName));
+    setAvatarUrl((prev) => (prev === photoUrl ? prev : photoUrl));
+    setAvatarInitials((prev) => (prev === initials ? prev : initials));
+  }, [displayName, photoUrl, initials]);
 
   const toggle = () =>
     setHide((v) => {
@@ -89,7 +98,17 @@ export default function HomePage() {
       <section className="home-hero">
         <div className="hero-top">
           <div className="user-chip">
-            <div style={{ fontWeight: 800 }}>{user}</div>
+            <div className="ava" aria-hidden={avatarUrl ? undefined : true}>
+              {avatarUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={avatarUrl} alt="" loading="lazy" />
+              ) : (
+                <span>{avatarInitials}</span>
+              )}
+            </div>
+            <div style={{ fontWeight: 800 }} title={userLabel}>
+              {userLabel}
+            </div>
           </div>
           <div className="badge-beta">beta ⓘ</div>
         </div>

--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -1,33 +1,73 @@
 'use client';
 
-export default function Verify(){
+import { useTelegramUser } from '@/lib/useTelegramUser';
+
+export default function Verify() {
+  const { displayName, initials, photoUrl, source } = useTelegramUser();
+  const plainName = displayName.replace(/^@/, '').trim();
+  const hasPersonalGreeting = source !== 'placeholder' && plainName.length > 0;
+  const heading = hasPersonalGreeting ? `Привет, ${plainName}!` : 'Добро пожаловать в CryptoBali';
+  const subtitle = hasPersonalGreeting
+    ? 'Это CryptoBali — сервис платежей и P2P-инструментов. Начнём?'
+    : 'Мы — сервис платежей и P2P-инструментов. Войдите через Telegram Web App.';
+
   return (
-    <div style={{
-      minHeight:'100svh',
-      background:'var(--bg)',
-      color:'var(--text)',
-      display:'flex',
-      flexDirection:'column',
-      alignItems:'center',
-      justifyContent:'center',
-      gap:14,
-      fontFamily:'system-ui',
-      padding:'0 16px',
-      textAlign:'center'
-    }}>
-      <h1 style={{margin:0}}>Добро пожаловать в CryptoBali</h1>
-      <div style={{color:'var(--muted)'}}>
-        Мы — сервис платежей и P2P-инструментов. Войдите через Telegram Web App.
-      </div>
+    <div
+      style={{
+        minHeight: '100svh',
+        background: 'var(--bg)',
+        color: 'var(--text)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 14,
+        fontFamily: 'system-ui',
+        padding: '0 16px',
+        textAlign: 'center',
+      }}
+    >
+      {hasPersonalGreeting && (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+          <div
+            style={{
+              width: 72,
+              height: 72,
+              borderRadius: '50%',
+              background: 'rgba(255,255,255,.08)',
+              border: '1px solid rgba(255,255,255,.24)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              overflow: 'hidden',
+              fontWeight: 800,
+              color: '#052235',
+            }}
+            aria-hidden={photoUrl ? undefined : true}
+          >
+            {photoUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={photoUrl} alt="" loading="lazy" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            ) : (
+              <span style={{ fontSize: 24 }}>{initials}</span>
+            )}
+          </div>
+          <div style={{ fontWeight: 800 }} title={displayName}>
+            {displayName}
+          </div>
+        </div>
+      )}
+      <h1 style={{ margin: 0 }}>{heading}</h1>
+      <div style={{ color: 'var(--muted)' }}>{subtitle}</div>
       <a
         href="/pin?mode=set"
         style={{
-          marginTop:8,
-          padding:'10px 14px',
-          border:'1px solid var(--primary)',
-          borderRadius:12,
-          textDecoration:'none',
-          color:'var(--text)'
+          marginTop: 8,
+          padding: '10px 14px',
+          border: '1px solid var(--primary)',
+          borderRadius: 12,
+          textDecoration: 'none',
+          color: 'var(--text)',
         }}
       >
         Создать быстрый доступ (PIN)

--- a/lib/useTelegramUser.ts
+++ b/lib/useTelegramUser.ts
@@ -1,0 +1,198 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { TGUser, getTG, getUser } from './tg';
+
+type ProfileSource = 'placeholder' | 'storage' | 'telegram' | 'mock';
+
+type TelegramProfile = {
+  user: TGUser | null;
+  username: string | null;
+  displayName: string;
+  photoUrl: string | null;
+  initials: string;
+  source: ProfileSource;
+};
+
+type UseTelegramUserOptions = {
+  /** Persist user details in localStorage for subsequent visits. */
+  persist?: boolean;
+};
+
+type UseTelegramUserResult = TelegramProfile & {
+  isLoading: boolean;
+  isMock: boolean;
+};
+
+const STORAGE_KEY = 'tgUserCache';
+const LEGACY_USERNAME_KEY = 'username';
+const LEGACY_PHOTO_KEY = 'userPhoto';
+
+const placeholderProfile: TelegramProfile = {
+  user: null,
+  username: null,
+  displayName: '@guest',
+  photoUrl: null,
+  initials: 'CB',
+  source: 'placeholder',
+};
+
+function ensureClient() {
+  return typeof window !== 'undefined' ? window : undefined;
+}
+
+function stripAt(username: string) {
+  return username.startsWith('@') ? username.slice(1) : username;
+}
+
+function ensureAt(username: string | null | undefined) {
+  if (!username) return null;
+  const trimmed = username.trim();
+  if (!trimmed) return null;
+  return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
+}
+
+function computeInitials(user: TGUser | null, displayName: string) {
+  const letters: string[] = [];
+  if (user?.first_name) letters.push(user.first_name.charAt(0));
+  if (user?.last_name) letters.push(user.last_name.charAt(0));
+  if (!letters.length && user?.username) letters.push(user.username.charAt(0));
+  if (!letters.length) {
+    const fallback = displayName.replace(/^@/, '').trim();
+    if (fallback) letters.push(fallback.charAt(0));
+  }
+  if (!letters.length) return 'CB';
+  return letters.join('').slice(0, 2).toUpperCase();
+}
+
+function normalizeUser(user: TGUser): TGUser {
+  return {
+    id: user.id,
+    username: user.username,
+    first_name: user.first_name,
+    last_name: user.last_name,
+    photo_url: user.photo_url,
+  };
+}
+
+function buildProfile(user: TGUser | null, source: ProfileSource): TelegramProfile {
+  if (!user) {
+    return { ...placeholderProfile, source };
+  }
+  const username = ensureAt(user.username);
+  const displayName = username ?? [user.first_name, user.last_name].filter(Boolean).join(' ').trim() || 'CryptoBali';
+  const photoUrl = user.photo_url ?? null;
+  const initials = computeInitials(user, displayName);
+  return {
+    user,
+    username,
+    displayName,
+    photoUrl,
+    initials,
+    source,
+  };
+}
+
+function readCachedUser(): TGUser | null {
+  const client = ensureClient();
+  if (!client) return null;
+  try {
+    const stored = client.localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored) as Partial<TGUser> & { id?: number };
+      if (parsed && typeof parsed === 'object') {
+        return normalizeUser({
+          id: typeof parsed.id === 'number' ? parsed.id : -1,
+          username: parsed.username,
+          first_name: parsed.first_name,
+          last_name: parsed.last_name,
+          photo_url: parsed.photo_url,
+        });
+      }
+    }
+  } catch {
+    // ignore parsing errors
+  }
+  try {
+    const legacyUsername = client.localStorage.getItem(LEGACY_USERNAME_KEY);
+    const legacyPhoto = client.localStorage.getItem(LEGACY_PHOTO_KEY);
+    if (legacyUsername || legacyPhoto) {
+      return normalizeUser({
+        id: -1,
+        username: legacyUsername ? stripAt(legacyUsername) : undefined,
+        first_name: undefined,
+        last_name: undefined,
+        photo_url: legacyPhoto ?? undefined,
+      });
+    }
+  } catch {
+    // ignore legacy access errors
+  }
+  return null;
+}
+
+function persistUser(user: TGUser) {
+  const client = ensureClient();
+  if (!client) return;
+  try {
+    const data = normalizeUser(user);
+    client.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    const usernameWithAt = ensureAt(data.username);
+    if (usernameWithAt) client.localStorage.setItem(LEGACY_USERNAME_KEY, usernameWithAt);
+    else client.localStorage.removeItem(LEGACY_USERNAME_KEY);
+    if (data.photo_url) client.localStorage.setItem(LEGACY_PHOTO_KEY, data.photo_url);
+    else client.localStorage.removeItem(LEGACY_PHOTO_KEY);
+  } catch {
+    // ignore persistence errors
+  }
+}
+
+export function useTelegramUser(options: UseTelegramUserOptions = {}): UseTelegramUserResult {
+  const { persist = true } = options;
+  const [profile, setProfile] = useState<TelegramProfile>(() => {
+    const cached = readCachedUser();
+    if (cached) return buildProfile(cached, 'storage');
+    return placeholderProfile;
+  });
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tgUser = getUser();
+    const tgInstance = getTG();
+
+    if (tgUser) {
+      const normalized = normalizeUser(tgUser);
+      const source: ProfileSource = tgInstance
+        ? 'telegram'
+        : process.env.NEXT_PUBLIC_TG_MOCK === '1'
+          ? 'mock'
+          : 'storage';
+      if (!cancelled) {
+        setProfile(buildProfile(normalized, source));
+        if (persist) persistUser(normalized);
+      }
+    } else {
+      const cached = readCachedUser();
+      if (!cancelled) {
+        if (cached) setProfile(buildProfile(cached, 'storage'));
+        else setProfile(placeholderProfile);
+      }
+    }
+
+    if (!cancelled) setIsLoading(false);
+    return () => {
+      cancelled = true;
+    };
+  }, [persist]);
+
+  return useMemo(
+    () => ({
+      ...profile,
+      isLoading,
+      isMock: profile.source === 'mock',
+    }),
+    [profile, isLoading],
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `useTelegramUser` hook that loads Telegram profile data, falls back to mock/locals, and caches values
- show the Telegram avatar/initials in the home user chip using the hook-driven state
- personalize the verify screen with the same hook so returning users are greeted immediately

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf26de5ca88326a388f1ea147c032e