### PR TITLE
Revamp PIN guard and add Face ID settings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,6 +46,128 @@ a{color:inherit;text-decoration:none}
 .key.big{grid-column:2/3}
 .topbar{position:sticky;top:0;background:var(--bg);padding:8px 16px;z-index:10}
 
+/* === PIN GUARD OVERLAY === */
+.pin-guard{
+  position:fixed;
+  inset:0;
+  z-index:2147483000;
+  padding:calc(env(safe-area-inset-top,0px) + 18px) 20px calc(env(safe-area-inset-bottom,0px) + 28px);
+  background:linear-gradient(180deg,#071426 0%,#0b2238 55%,#0f273f 100%);
+  color:#fff;
+  display:flex;
+  justify-content:center;
+  align-items:stretch;
+}
+.pin-guard__wrap{
+  width:100%;
+  max-width:420px;
+  display:flex;
+  flex-direction:column;
+  min-height:100%;
+  gap:24px;
+}
+.pin-guard__head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  font-weight:700;
+  letter-spacing:.01em;
+}
+.pin-guard__close{
+  border:none;
+  background:transparent;
+  color:rgba(255,255,255,.9);
+  font-size:15px;
+  font-weight:700;
+  padding:6px 0;
+  cursor:pointer;
+}
+.pin-guard__close:active{opacity:.6}
+.pin-guard__app{text-align:center;line-height:1.2}
+.pin-guard__appTitle{font-size:16px;font-weight:800}
+.pin-guard__appSubtitle{font-size:12px;color:rgba(255,255,255,.55);font-weight:600}
+.pin-guard__stub{width:64px}
+.pin-guard__body{
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  justify-content:space-between;
+  gap:32px;
+}
+.pin-guard__content{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  text-align:center;
+  gap:18px;
+}
+.pin-guard__content.is-shake{animation:pin-guard-shake .42s ease}
+.pin-guard__title{margin:0;font-size:26px;font-weight:800;letter-spacing:.01em}
+.pin-guard__dots{display:flex;gap:12px}
+.pin-guard__dot{
+  width:12px;
+  height:12px;
+  border-radius:999px;
+  background:rgba(255,255,255,.24);
+  transition:transform .2s ease,background .2s ease,box-shadow .2s ease;
+}
+.pin-guard__dot.on{
+  background:#fff;
+  transform:scale(1.2);
+  box-shadow:0 0 0 4px rgba(255,255,255,.16);
+}
+.pin-guard__error{min-height:20px;font-size:13px;font-weight:700;color:#ff8080}
+.pin-guard__face{
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  padding:10px 16px;
+  border-radius:18px;
+  border:1px solid rgba(255,255,255,.28);
+  background:rgba(255,255,255,.12);
+  backdrop-filter:blur(18px);
+  color:#fff;
+  font-weight:700;
+  font-size:14px;
+  cursor:pointer;
+  transition:transform .15s ease,background .15s ease;
+}
+.pin-guard__face svg{width:22px;height:22px}
+.pin-guard__face:disabled{opacity:.45;cursor:default}
+.pin-guard__face:not(:disabled):active{transform:scale(.97);background:rgba(255,255,255,.2)}
+.pin-guard__keypad{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(72px,1fr));
+  gap:18px;
+}
+.pin-guard__key{
+  height:72px;
+  border-radius:32px;
+  border:1px solid rgba(255,255,255,.18);
+  background:rgba(255,255,255,.1);
+  backdrop-filter:blur(18px);
+  color:#fff;
+  font-size:28px;
+  font-weight:700;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  transition:transform .15s ease,background .15s ease;
+}
+.pin-guard__key[data-variant="exit"]{font-size:15px;font-weight:600;letter-spacing:.02em}
+.pin-guard__key[data-variant="back"]{font-size:34px}
+.pin-guard__key:active{transform:scale(.95);background:rgba(255,255,255,.2)}
+.pin-guard__close:focus-visible,
+.pin-guard__face:focus-visible,
+.pin-guard__key:focus-visible{outline:2px solid rgba(255,255,255,.65);outline-offset:4px}
+
+@keyframes pin-guard-shake{
+  0%,100%{transform:translateX(0)}
+  15%,55%{transform:translateX(-10px)}
+  35%,75%{transform:translateX(10px)}
+}
+
 /* === */
 .tabbar{display:flex;justify-content:space-between;align-items:center;width:100%}
 .tabbar .tabitem{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;flex:1;text-decoration:none;color:var(--text);padding:8px 0}
@@ -449,6 +571,7 @@ header a,header button,.header a,.header button{ pointer-events:auto; }
 .row-pill[data-on="1"]{
   background:#e8f9ef; border-color:#c5f0d4; color:#138a42;
 }
+.row-pill[disabled]{opacity:.55; cursor:default; filter:grayscale(.2);}
 
 /* Check mark for selected language */
 .row-check{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import TabBar from '../components/ui/TabBar';
 import { Web3Provider } from '../components/providers/Web3';
 
 import TgInit from '../components/providers/TgInit';
+import PinGuard from '../components/security/PinGuard';
 
 export const metadata = {
   title: 'CryptoBali — Профиль',
@@ -16,11 +17,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
-      <TgInit />
+        <TgInit />
         <Web3Provider>
-        <Providers>
-          {children}
-        </Providers>
+          <Providers>
+            {children}
+            <PinGuard />
+          </Providers>
         </Web3Provider>
 
         <TabBar />

--- a/app/settings/security/page.tsx
+++ b/app/settings/security/page.tsx
@@ -1,23 +1,79 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { tr } from '../../../components/ui/tr';
 
 export default function SecurityPage(){
   const [email,setEmail] = useState<string|undefined>();
   const [verified,setVerified] = useState(false);
   const [pin,setPin] = useState(false);
+  const [face,setFace] = useState(false);
+  const [faceSupported,setFaceSupported] = useState(true);
   const [hide,setHide] = useState(false);
 
   useEffect(()=>{ try{
     setEmail(localStorage.getItem('userEmail')||undefined);
     setVerified(localStorage.getItem('userEmailVerified')==='1');
     setPin(localStorage.getItem('pin_enabled')==='1');
+    setFace(localStorage.getItem('faceid_enabled')==='1');
     setHide(localStorage.getItem('hideBalance')==='1');
   }catch{} },[]);
+
+  useEffect(()=>{
+    let cancelled = false;
+    const manager = (window as any)?.Telegram?.WebApp?.BiometricsManager;
+    if (!manager) {
+      setFaceSupported(false);
+      return;
+    }
+    const detect = async () => {
+      try {
+        const availableRes = await manager.isBiometricsAvailable?.();
+        if (!availableRes?.available) {
+          if (!cancelled) setFaceSupported(false);
+          return;
+        }
+        const enrolledRes = await manager.isBiometricsEnrolled?.();
+        if (!cancelled) {
+          const allowed = enrolledRes ? Boolean(enrolledRes.enrolled || enrolledRes.canEnroll) : true;
+          setFaceSupported(allowed);
+        }
+      } catch {
+        if (!cancelled) setFaceSupported(false);
+      }
+    };
+    detect();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(()=>{
+    const sync = () => {
+      try {
+        setPin(localStorage.getItem('pin_enabled')==='1');
+        setHide(localStorage.getItem('hideBalance')==='1');
+        setFace(localStorage.getItem('faceid_enabled')==='1');
+      } catch{}
+    };
+    window.addEventListener('storage', sync);
+    return () => window.removeEventListener('storage', sync);
+  }, []);
 
   const toggle = (key:string, setter: React.Dispatch<React.SetStateAction<boolean>>)=>()=>{
     setter(v=>{ const n=!v; try{ localStorage.setItem(key, n?'1':'0'); }catch{}; return n; });
   };
+
+  const toggleFace = useCallback(()=>{
+    if (!faceSupported) return;
+    setFace(v=>{
+      const next=!v;
+      try{
+        localStorage.setItem('faceid_enabled', next?'1':'0');
+        if (!next) localStorage.removeItem('pin_ok');
+      }catch{}
+      return next;
+    });
+  },[faceSupported]);
 
   return (
     <div style={{maxWidth:480, margin:'0 auto 96px', padding:'12px 16px'}}>
@@ -40,6 +96,23 @@ export default function SecurityPage(){
           <button className="row-pill" data-on={pin?1:0} onClick={toggle('pin_enabled', setPin)}>{tr('security','toggle_pin','Переключить PIN')}</button>
         </div>
         <div className="list-row">
+          <span className="row-ico">{IconFace()}</span>
+          <span className="row-label">
+            {faceSupported
+              ? (face ? 'Face ID: включён' : 'Face ID: выключен')
+              : 'Face ID: недоступен'}
+          </span>
+          <button
+            type="button"
+            className="row-pill"
+            data-on={face?1:0}
+            onClick={toggleFace}
+            disabled={!faceSupported}
+          >
+            {faceSupported ? (face ? 'Отключить' : 'Включить') : 'Недоступно'}
+          </button>
+        </div>
+        <div className="list-row">
           <span className="row-ico">{IconEye()}</span>
           <span className="row-label">{hide?tr('security','hide_on','Скрывать баланс: да'):tr('security','hide_off','Скрывать баланс: нет')}</span>
           <button className="row-pill" data-on={hide?1:0} onClick={toggle('hideBalance', setHide)}>{tr('security','toggle_hide','Скрывать баланс')}</button>
@@ -51,4 +124,5 @@ export default function SecurityPage(){
 
 function IconMail(){return(<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M4 6h16v12H4z"/><path d="M4 8l8 6 8-6"/></svg>);}
 function IconPin(){return(<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="5" y="10" width="14" height="10" rx="2"/><path d="M8 10V7a4 4 0 1 1 8 0v3"/></svg>);}
+function IconFace(){return(<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 7V5a2 2 0 0 1 2-2h2"/><path d="M20 7V5a2 2 0 0 0-2-2h-2"/><path d="M4 17v2a2 2 0 0 0 2 2h2"/><path d="M20 17v2a2 2 0 0 1-2 2h-2"/><path d="M9 10.5c.5-.5 1.1-.8 2-.8s1.5.3 2 .8"/><path d="M13 10.5c.5-.5 1.1-.8 2-.8s1.5.3 2 .8"/><path d="M9 15c.7.7 1.5 1 3 1s2.3-.3 3-1"/></svg>);}
 function IconEye(){return(<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12z"/><circle cx="12" cy="12" r="3"/></svg>);}

--- a/components/security/PinGuard.tsx
+++ b/components/security/PinGuard.tsx
@@ -1,66 +1,321 @@
 'use client';
 import React from 'react';
+import { usePathname } from 'next/navigation';
 
-export default function PinGuard(){
+const SKIP_PREFIXES = ['/verify', '/pin', '/scan'];
+const KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'exit', '0', 'back'] as const;
+type KeyType = (typeof KEYS)[number];
+
+export default function PinGuard() {
+  const pathname = usePathname() || '';
   const [needPin, setNeedPin] = React.useState(false);
+  const [pinValue, setPinValue] = React.useState('');
+  const [pinLength, setPinLength] = React.useState(4);
   const [code, setCode] = React.useState('');
   const [err, setErr] = React.useState('');
+  const [shake, setShake] = React.useState(false);
+  const [faceEnabled, setFaceEnabled] = React.useState(false);
+  const [faceAvailable, setFaceAvailable] = React.useState(false);
+  const [faceAttempted, setFaceAttempted] = React.useState(false);
+  const [faceLoading, setFaceLoading] = React.useState(false);
+  const shouldSkip = React.useMemo(() => SKIP_PREFIXES.some(prefix => pathname.startsWith(prefix)), [pathname]);
 
-  React.useEffect(()=>{
+  const evaluateNeedPin = React.useCallback(() => {
     try {
       const enabled = localStorage.getItem('pin_enabled') === '1';
-      const pin = localStorage.getItem('pin_code') || '';
+      const storedPin = localStorage.getItem('pin_code') || '';
       const ok = localStorage.getItem('pin_ok') === '1';
-      if (enabled && pin && !ok) setNeedPin(true);
-    } catch {}
+      const face = localStorage.getItem('faceid_enabled') === '1';
+      setPinValue(storedPin);
+      setPinLength(storedPin.length > 0 ? Math.max(storedPin.length, 4) : 4);
+      setFaceEnabled(face);
+      const required = Boolean(enabled && storedPin && !ok);
+      setNeedPin(required);
+      if (!required) {
+        setCode('');
+        setErr('');
+        setShake(false);
+        setFaceAttempted(false);
+        setFaceLoading(false);
+      }
+    } catch {
+      setNeedPin(false);
+    }
   }, []);
 
-  const submit = ()=>{
+  React.useEffect(() => {
+    evaluateNeedPin();
+  }, [evaluateNeedPin, pathname]);
+
+  React.useEffect(() => {
+    const onStorage = () => evaluateNeedPin();
+    const onFocus = () => evaluateNeedPin();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') evaluateNeedPin();
+    };
+    window.addEventListener('storage', onStorage);
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [evaluateNeedPin]);
+
+  React.useEffect(() => {
+    let active = true;
+    const checkFace = async () => {
+      if (!needPin || !faceEnabled) {
+        if (active) setFaceAvailable(false);
+        return;
+      }
+      const manager = (window as any)?.Telegram?.WebApp?.BiometricsManager;
+      if (!manager) {
+        if (active) setFaceAvailable(false);
+        return;
+      }
+      try {
+        const availableRes = await manager.isBiometricsAvailable?.();
+        if (!availableRes?.available) {
+          if (active) setFaceAvailable(false);
+          return;
+        }
+        const enrolledRes = await manager.isBiometricsEnrolled?.();
+        if (!active) return;
+        const allowed = enrolledRes ? Boolean(enrolledRes.enrolled || enrolledRes.canEnroll) : true;
+        setFaceAvailable(allowed);
+      } catch {
+        if (active) setFaceAvailable(false);
+      }
+    };
+    checkFace();
+    return () => {
+      active = false;
+    };
+  }, [needPin, faceEnabled]);
+
+  const shakeTimer = React.useRef<ReturnType<typeof setTimeout>>();
+  React.useEffect(() => {
+    return () => {
+      if (shakeTimer.current) clearTimeout(shakeTimer.current);
+    };
+  }, []);
+
+  const prevNeedPin = React.useRef(false);
+  React.useEffect(() => {
+    if (needPin && !prevNeedPin.current) {
+      setCode('');
+      setErr('');
+      setShake(false);
+      setFaceAttempted(false);
+      setFaceLoading(false);
+    }
+    prevNeedPin.current = needPin;
+  }, [needPin]);
+
+  const checkPin = React.useCallback((value: string) => {
     try {
-      const pin = localStorage.getItem('pin_code') || '';
-      if (!pin) { setNeedPin(false); return; }
-      if (code === pin){
-        localStorage.setItem('pin_ok','1');
+      const pin = pinValue;
+      if (!pin) {
+        setNeedPin(false);
+        return;
+      }
+      if (value === pin) {
+        localStorage.setItem('pin_ok', '1');
         setErr('');
         setNeedPin(false);
+        setCode('');
+        setFaceAttempted(false);
       } else {
-        setErr('Неверный PIN');
+        setErr('Неверный PIN-код');
+        setCode('');
+        setShake(true);
+        if (shakeTimer.current) clearTimeout(shakeTimer.current);
+        shakeTimer.current = setTimeout(() => setShake(false), 420);
+      }
+    } catch {
+      setNeedPin(false);
+    }
+  }, [pinValue]);
+
+  React.useEffect(() => {
+    if (!needPin) return;
+    if (!pinValue) return;
+    if (code.length === pinValue.length && pinValue.length > 0) {
+      checkPin(code);
+    }
+  }, [code, needPin, pinValue, checkPin]);
+
+  const handleDigit = React.useCallback((digit: string) => {
+    setCode(prev => {
+      if (prev.length >= pinLength) return prev;
+      return prev + digit;
+    });
+    if (err) setErr('');
+  }, [pinLength, err]);
+
+  const handleBackspace = React.useCallback(() => {
+    setCode(prev => prev.slice(0, -1));
+    if (err) setErr('');
+  }, [err]);
+
+  const handleExit = React.useCallback(() => {
+    try {
+      localStorage.removeItem('pin_ok');
+    } catch {}
+    window.location.href = '/profile';
+  }, []);
+
+  const handleClose = React.useCallback(() => {
+    try {
+      const tg = (window as any)?.Telegram?.WebApp;
+      if (tg?.close) {
+        tg.close();
+        return;
       }
     } catch {}
-  };
+    try { window.history.back(); } catch {}
+  }, []);
 
-  const onInput = (v:string)=>{
-    const s = v.replace(/\D/g,'').slice(0,6);
-    setCode(s);
-    setErr('');
-  };
+  const tryFaceId = React.useCallback(async () => {
+    const manager = (window as any)?.Telegram?.WebApp?.BiometricsManager;
+    if (!manager) {
+      setErr('Face ID недоступен');
+      setFaceAttempted(true);
+      return;
+    }
+    try {
+      setFaceLoading(true);
+      setErr('');
+      const res = await manager.authenticate?.({ reason: 'Подтвердите личность' });
+      if (res?.success) {
+        localStorage.setItem('pin_ok', '1');
+        setNeedPin(false);
+        setCode('');
+        setFaceAttempted(false);
+        return;
+      }
+      setErr('Не удалось подтвердить Face ID');
+    } catch {
+      setErr('Не удалось подтвердить Face ID');
+    } finally {
+      setFaceLoading(false);
+      setFaceAttempted(true);
+    }
+  }, []);
 
-  if (!needPin) return null;
+  React.useEffect(() => {
+    if (needPin && faceEnabled && faceAvailable && !faceAttempted) {
+      tryFaceId();
+    }
+  }, [needPin, faceEnabled, faceAvailable, faceAttempted, tryFaceId]);
+
+  React.useEffect(() => {
+    if (!needPin) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key >= '0' && event.key <= '9') {
+        event.preventDefault();
+        handleDigit(event.key);
+      } else if (event.key === 'Backspace') {
+        event.preventDefault();
+        handleBackspace();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        handleClose();
+      } else if (event.key === 'Enter') {
+        if (pinValue && code.length === pinValue.length) {
+          event.preventDefault();
+          checkPin(code);
+        }
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [needPin, handleDigit, handleBackspace, handleClose, checkPin, pinValue, code]);
+
+  const onKeyPress = React.useCallback((key: KeyType) => {
+    if (key === 'exit') {
+      handleExit();
+      return;
+    }
+    if (key === 'back') {
+      handleBackspace();
+      return;
+    }
+    handleDigit(key);
+  }, [handleExit, handleBackspace, handleDigit]);
+
+  if (!needPin || shouldSkip) return null;
 
   return (
-    <div style={{ position:'fixed', inset:0, zIndex:9999, background:'rgba(6,11,20,.6)', backdropFilter:'blur(6px)', display:'grid', placeItems:'center', padding:'24px' }}>
-      <div style={{ width:'100%', maxWidth:420, background:'#fff', color:'#0b1b2b', borderRadius:20, boxShadow:'0 10px 30px rgba(0,0,0,.25)', padding:18, display:'grid', gap:12 }}>
-        <div style={{display:'flex', alignItems:'center', gap:10}}>
-          <div style={{width:40,height:40,borderRadius:12,background:'#e8f1ff',display:'flex',alignItems:'center',justifyContent:'center',fontWeight:900}}>🔒</div>
-          <div>
-            <div style={{fontWeight:900, fontSize:18}}>Введите PIN</div>
-            <div style={{fontSize:12, color:'#64748b'}}>Для доступа к приложению</div>
+    <div className="pin-guard">
+      <div className="pin-guard__wrap" role="dialog" aria-modal="true" aria-label="PIN защита">
+        <header className="pin-guard__head">
+          <button type="button" className="pin-guard__close" onClick={handleClose}>
+            Закрыть
+          </button>
+          <div className="pin-guard__app">
+            <div className="pin-guard__appTitle">Antarctic Wallet</div>
+            <div className="pin-guard__appSubtitle">мини-приложение</div>
+          </div>
+          <div className="pin-guard__stub" aria-hidden="true" />
+        </header>
+
+        <div className="pin-guard__body">
+          <div className={`pin-guard__content${shake ? ' is-shake' : ''}`}>
+            <h1 className="pin-guard__title">Введите PIN-код</h1>
+            <div className="pin-guard__dots" aria-hidden="true">
+              {Array.from({ length: pinLength }, (_, idx) => (
+                <span key={idx} className={`pin-guard__dot${idx < code.length ? ' on' : ''}`} />
+              ))}
+            </div>
+            <div className="pin-guard__error" aria-live="polite">
+              {err || '\u00A0'}
+            </div>
+            {faceEnabled && faceAvailable && (
+              <button
+                type="button"
+                className="pin-guard__face"
+                onClick={tryFaceId}
+                disabled={faceLoading}
+              >
+                <FaceIcon />
+                <span>{faceLoading ? 'Ожидание…' : 'Войти с Face ID'}</span>
+              </button>
+            )}
+          </div>
+
+          <div className="pin-guard__keypad">
+            {KEYS.map(key => (
+              <button
+                key={key}
+                type="button"
+                className="pin-guard__key"
+                data-variant={key === 'exit' ? 'exit' : key === 'back' ? 'back' : undefined}
+                onClick={() => onKeyPress(key)}
+                aria-label={key === 'exit' ? 'Выйти' : key === 'back' ? 'Удалить' : `Цифра ${key}`}
+              >
+                {key === 'exit' ? 'Выйти' : key === 'back' ? '×' : key}
+              </button>
+            ))}
           </div>
         </div>
-
-        <input
-          autoFocus inputMode="numeric" pattern="[0-9]*" placeholder="••••"
-          value={code} onChange={e=>onInput(e.target.value)}
-          onKeyDown={e=>{ if(e.key==='Enter') submit(); }}
-          style={{ fontSize:22, letterSpacing:'6px', textAlign:'center', padding:'12px 14px', borderRadius:14, border:'1px solid #e5e7eb' }}
-        />
-
-        {err && <div style={{color:'#dc2626', fontSize:12}}>{err}</div>}
-
-        <button onClick={submit} style={{width:'100%', background:'#2d6cf6', color:'#fff', border:'none', borderRadius:14, padding:'12px 16px', fontWeight:900}}>
-          Разблокировать
-        </button>
       </div>
     </div>
+  );
+}
+
+function FaceIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 7V5a2 2 0 0 1 2-2h2" />
+      <path d="M20 7V5a2 2 0 0 0-2-2h-2" />
+      <path d="M4 17v2a2 2 0 0 0 2 2h2" />
+      <path d="M20 17v2a2 2 0 0 1-2 2h-2" />
+      <path d="M9 10.5c.5-.5 1.1-.8 2-.8s1.5.3 2 .8" />
+      <path d="M13 10.5c.5-.5 1.1-.8 2-.8s1.5.3 2 .8" />
+      <path d="M9 15c.7.7 1.5 1 3 1s2.3-.3 3-1" />
+    </svg>
   );
 }


### PR DESCRIPTION
## Summary
- redesign the always-on PIN guard with a keypad overlay, Face ID integration and navigation/event re-evaluation
- add a Face ID status toggle to the security settings page alongside existing PIN controls
- extend global styles for the new guard surface and disabled toggles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf26ea6b6c8326a3e8eb0131e92e28