### PR TITLE
Restore post-unlock redirect

### DIFF
--- a/app/pin/page.tsx
+++ b/app/pin/page.tsx
@@ -1,23 +1,160 @@
 'use client';
-import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const DEFAULT_PIN_LENGTH = 4;
+
+type NavigatorWithCredentials = Navigator & {
+  credentials?: {
+    get?: (options?: CredentialRequestOptions) => Promise<Credential | null>;
+  };
+};
+
+type Mode = 'set' | 'unlock';
 
 export default function PinPage(){
-  const [pin,setPin]=useState('');
-  const router=useRouter();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [pin,setPin] = useState('');
+  const [error,setError] = useState('');
+  const [hydrated,setHydrated] = useState(false);
+  const [pinStored,setPinStored] = useState('');
+  const [pinEnabled,setPinEnabled] = useState(false);
+  const [pinOk,setPinOk] = useState(false);
+  const [biometryPayload,setBiometryPayload] = useState<string|null>(null);
+  const [canUseBiometry,setCanUseBiometry] = useState(false);
 
-  useEffect(()=>{ if(pin.length===4){ setTimeout(()=>router.push('/home' as any),200); } },[pin,router]);
+  const mode:Mode = searchParams?.get('mode') === 'set' ? 'set' : 'unlock';
 
-  const press=(v:string)=>{
-    if(v==='back'){ setPin(p=>p.slice(0,-1)); return; }
-    if(v==='clear'){ setPin(''); return; }
-    if(pin.length<4) setPin(pin+v);
+  const redirectTarget = useMemo(()=>{
+    const ref = searchParams?.get('ref');
+    if (ref && ref.startsWith('/')) return ref;
+    return '/home';
+  },[searchParams]);
+
+  const pinLength = mode === 'set'
+    ? DEFAULT_PIN_LENGTH
+    : (pinStored.length || DEFAULT_PIN_LENGTH);
+
+  useEffect(()=>{
+    try {
+      const stored = localStorage.getItem('pin_code') || '';
+      const enabled = localStorage.getItem('pin_enabled') === '1';
+      setPinStored(stored);
+      setPinEnabled(enabled && stored.length > 0);
+      const payload = localStorage.getItem('pin_biometry_request') ?? localStorage.getItem('pin_biometry');
+      setBiometryPayload(payload);
+      if (payload) {
+        const nav = typeof window !== 'undefined' ? (navigator as NavigatorWithCredentials) : undefined;
+        setCanUseBiometry(Boolean(nav?.credentials?.get) || payload.trim() === 'ok');
+      } else {
+        setCanUseBiometry(false);
+      }
+    } catch {}
+    setHydrated(true);
+  },[]);
+
+  useEffect(()=>{
+    if (!hydrated || mode !== 'unlock' || pinOk) return;
+    if (!pinEnabled) {
+      try { localStorage.setItem('pin_ok','1'); } catch {}
+      setPinOk(true);
+      router.replace(redirectTarget);
+    }
+  },[hydrated, mode, pinEnabled, pinOk, router, redirectTarget]);
+
+  useEffect(()=>{
+    if (!hydrated || pinOk) return;
+    if (pin.length < pinLength) return;
+
+    if (mode === 'set') {
+      try {
+        localStorage.setItem('pin_code', pin);
+        localStorage.setItem('pin_enabled','1');
+        localStorage.setItem('pin_ok','1');
+      } catch {}
+      setPinOk(true);
+      router.replace(redirectTarget);
+      return;
+    }
+
+    if (!pinEnabled) {
+      try { localStorage.setItem('pin_ok','1'); } catch {}
+      setPinOk(true);
+      router.replace(redirectTarget);
+      return;
+    }
+
+    if (pinStored && pin === pinStored) {
+      try { localStorage.setItem('pin_ok','1'); } catch {}
+      setPinOk(true);
+      setError('');
+      router.replace(redirectTarget);
+    } else {
+      setError('Неверный PIN');
+      setPin('');
+    }
+  },[hydrated, mode, pin, pinEnabled, pinStored, pinLength, pinOk, router, redirectTarget]);
+
+  const runBiometry = useCallback(async ()=>{
+    if (mode !== 'unlock' || pinOk) return;
+    const payload = biometryPayload?.trim();
+    if (!payload) return;
+
+    try {
+      if (payload === 'ok') {
+        try { localStorage.setItem('pin_ok','1'); } catch {}
+        setPinOk(true);
+        setError('');
+        router.replace(redirectTarget);
+        return;
+      }
+
+      const nav = navigator as NavigatorWithCredentials;
+      if (!nav?.credentials?.get) return;
+
+      const options = JSON.parse(payload) as CredentialRequestOptions;
+      const credential = await nav.credentials.get(options);
+      if (credential) {
+        try { localStorage.setItem('pin_ok','1'); } catch {}
+        setPinOk(true);
+        setError('');
+        router.replace(redirectTarget);
+      }
+    } catch {}
+  },[mode, pinOk, biometryPayload, router, redirectTarget]);
+
+  const press = (value:string)=>{
+    if (!hydrated || pinOk) return;
+    if (value === 'back') {
+      setPin(prev=>prev.slice(0,-1));
+      setError('');
+      return;
+    }
+    if (value === 'clear') {
+      setPin('');
+      setError('');
+      return;
+    }
+    if (!/^\d$/.test(value)) return;
+    setPin(prev=>{
+      if (prev.length >= pinLength) return prev;
+      return prev + value;
+    });
+    setError('');
   };
 
   return (
     <div style={{maxWidth:420, margin:'32px auto'}}>
-      <div style={{textAlign:'center',margin:'24px 0 8px',fontSize:22,fontWeight:700}}>Введите PIN-код</div>
-      <div className="dotRow">{[0,1,2,3].map(i=> <div key={i} className={`dot ${pin.length>i?'on':''}`}/>)}</div>
+      <div style={{textAlign:'center',margin:'24px 0 8px',fontSize:22,fontWeight:700}}>{mode==='set'?'Создайте PIN-код':'Введите PIN-код'}</div>
+      <div className="dotRow">{
+        Array.from({length:pinLength}).map((_,i)=> (
+          <div key={i} className={`dot ${pin.length>i?'on':''}`}/>
+        ))
+      }</div>
+      {error && (
+        <div style={{color:'#dc2626', textAlign:'center', fontSize:12, marginTop:8}}>{error}</div>
+      )}
       <div className="keypad">
         {['1','2','3','4','5','6','7','8','9','back','0','clear'].map((k,i)=>(
           <button key={i} className={`key${k==='0'?' big':''}`} onClick={()=>press(k)}>
@@ -25,9 +162,27 @@ export default function PinPage(){
           </button>
         ))}
       </div>
+      {canUseBiometry && (
+        <button
+          type="button"
+          onClick={runBiometry}
+          style={{
+            width:'100%',
+            marginTop:12,
+            padding:'10px 12px',
+            borderRadius:12,
+            border:'1px solid rgba(45,108,246,.35)',
+            background:'rgba(45,108,246,.08)',
+            color:'#2d6cf6',
+            fontWeight:600
+          }}
+        >
+          Разблокировать биометрией
+        </button>
+      )}
       <div style={{display:'flex',justifyContent:'space-between',marginTop:12}}>
         <a href="/profile" className="muted">Выйти</a>
-        <span className="muted">{pin.length}/4</span>
+        <span className="muted">{pin.length}/{pinLength}</span>
       </div>
     </div>
   );

--- a/docs/checklists/pin.md
+++ b/docs/checklists/pin.md
@@ -1,0 +1,5 @@
+# PIN checklist
+
+- Confirm the PIN keypad unlock flow sets `localStorage.pin_ok = '1'` and immediately redirects to the `ref` route (or `/home` when no ref is provided).
+- Verify biometric unlock mirrors the manual flow by setting `pin_ok` and performing the same redirect on success.
+- After unlocking, the standalone `/pin` screen should close and leave the user on the protected destination.

--- a/tests/pin-navigation.spec.ts
+++ b/tests/pin-navigation.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.BASE_URL || 'http://localhost:3010';
+
+const gotoPin = async (page: import('@playwright/test').Page, query = '') => {
+  await page.goto(`${BASE}/pin${query}`, { waitUntil: 'domcontentloaded' });
+};
+
+test.describe('PIN unlock navigation', () => {
+  test('manual PIN entry redirects after unlock', async ({ page }) => {
+    page.addInitScript(() => {
+      localStorage.setItem('pin_enabled', '1');
+      localStorage.setItem('pin_code', '2468');
+      localStorage.removeItem('pin_ok');
+      localStorage.removeItem('pin_biometry');
+      localStorage.removeItem('pin_biometry_request');
+    });
+
+    await gotoPin(page, '?ref=/home');
+
+    for (const digit of ['2', '4', '6', '8']) {
+      await page.getByRole('button', { name: digit }).click();
+    }
+
+    await page.waitForURL(`${BASE}/home`, { timeout: 5000 });
+
+    const pinOk = await page.evaluate(() => localStorage.getItem('pin_ok'));
+    expect(pinOk).toBe('1');
+  });
+
+  test('biometric unlock mirrors manual redirect', async ({ page }) => {
+    page.addInitScript(() => {
+      localStorage.setItem('pin_enabled', '1');
+      localStorage.setItem('pin_code', '1357');
+      localStorage.removeItem('pin_ok');
+      localStorage.setItem('pin_biometry', 'ok');
+    });
+
+    await gotoPin(page, '?ref=/home');
+
+    await page.getByRole('button', { name: 'Разблокировать биометрией' }).click();
+
+    await page.waitForURL(`${BASE}/home`, { timeout: 5000 });
+
+    const pinOk = await page.evaluate(() => localStorage.getItem('pin_ok'));
+    expect(pinOk).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the PIN page reads search params and redirects after successful manual unlock while keeping `pin_ok` in sync
- add the same redirect handling to biometric unlock, only exposing the button when the browser can satisfy the stored payload
- document the post-unlock navigation requirement and cover the redirect flows with new Playwright checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf2d6043ec832686d530595c2291f9