### PR TITLE
Add email verification API endpoints and client flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,26 @@ npm run dev
 ## Prefill из URL
 - `?asset=ton&to=EQ...&amount=1.2&comment=Coffee`
 - `?asset=jetton&jetton=kQ...&to=EQ...&amount=5&comment=tip`
+
+## SMTP для подтверждения e-mail
+Для работы серверных эндпоинтов `/api/email/verification/*` необходимо настроить SMTP.
+Добавьте переменные в `.env.local`:
+
+```env
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false # true для 465
+SMTP_USER=no-reply@example.com
+SMTP_PASS=your_password
+# Поле From (можно указать в формате "Имя <email@example.com>")
+SMTP_FROM="CryptoBali <no-reply@example.com>"
+
+# альтернативно можно использовать готовую строку подключения
+# SMTP_URL=smtp://user:pass@smtp.example.com:587
+
+# В разработке можно вывести код в лог, не отправляя письмо
+# EMAIL_DEBUG=1
+```
+
+После изменения переменных перезапустите dev-сервер. Если SMTP недоступен,
+эндпоинт вернёт ошибку `smtp-not-configured`.

--- a/app/api/email/verification/confirm/route.ts
+++ b/app/api/email/verification/confirm/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { memdb } from "@/lib/memdb";
+import { validateEmailFormat } from "@/lib/email-util";
+
+export const runtime = "nodejs";
+
+const MAX_ATTEMPTS = 5;
+
+function sessionKey(userId: string | undefined, email: string): string {
+  return `${userId ? String(userId) : "anon"}::${email.toLowerCase()}`;
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({} as Record<string, unknown>));
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+  const code = typeof body.code === "string" ? body.code.trim() : "";
+  const userId = body.userId ? String(body.userId) : undefined;
+
+  if (!validateEmailFormat(email)) {
+    return NextResponse.json(
+      { ok: false, error: "invalid-email" },
+      { status: 400 }
+    );
+  }
+
+  if (!/^\d{6}$/.test(code)) {
+    return NextResponse.json(
+      { ok: false, error: "invalid-code" },
+      { status: 400 }
+    );
+  }
+
+  const key = sessionKey(userId, email);
+  const session = memdb.emailSessions.get(key);
+
+  if (!session) {
+    return NextResponse.json(
+      { ok: false, error: "no-session" },
+      { status: 404 }
+    );
+  }
+
+  const now = Date.now();
+  if (now > session.expiresAt) {
+    memdb.emailSessions.delete(key);
+    return NextResponse.json(
+      { ok: false, error: "expired" },
+      { status: 410 }
+    );
+  }
+
+  if (session.code !== code) {
+    session.attempts += 1;
+    const attemptsLeft = Math.max(0, MAX_ATTEMPTS - session.attempts);
+    if (session.attempts >= MAX_ATTEMPTS) {
+      memdb.emailSessions.delete(key);
+      return NextResponse.json(
+        { ok: false, error: "too-many-attempts" },
+        { status: 429 }
+      );
+    }
+    memdb.emailSessions.set(key, session);
+    return NextResponse.json(
+      { ok: false, error: "mismatch", attemptsLeft },
+      { status: 400 }
+    );
+  }
+
+  memdb.emailSessions.delete(key);
+
+  const ownerKey = userId ? String(userId) : "anon";
+  const current = memdb.profiles.get(ownerKey) || { emailVerified: false };
+  const verifiedAt = Date.now();
+
+  const profile = {
+    ...current,
+    email: session.email,
+    emailVerified: true,
+    verifiedAt,
+  };
+  memdb.profiles.set(ownerKey, profile);
+
+  return NextResponse.json({ ok: true, profile });
+}

--- a/app/api/email/verification/start/route.ts
+++ b/app/api/email/verification/start/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from "next/server";
+import nodemailer, { Transporter } from "nodemailer";
+import { memdb } from "@/lib/memdb";
+import { validateEmailFormat } from "@/lib/email-util";
+
+export const runtime = "nodejs";
+
+const DEFAULT_TTL = 600;
+const MIN_TTL = 60;
+const MAX_TTL = 1800;
+const COOLDOWN_MS = 30_000;
+const CODE_LENGTH = 6;
+const EMAIL_DEBUG = process.env.EMAIL_DEBUG === "1";
+
+let cachedTransporter: Transporter | null = null;
+
+function buildTransporter(): Transporter | null {
+  if (cachedTransporter) return cachedTransporter;
+
+  const url = process.env.SMTP_URL;
+  if (url) {
+    cachedTransporter = nodemailer.createTransport(url);
+    return cachedTransporter;
+  }
+
+  const host = process.env.SMTP_HOST;
+  if (!host) return null;
+
+  const port = Number(process.env.SMTP_PORT || 587);
+  const secure = process.env.SMTP_SECURE
+    ? ["1", "true", "yes"].includes(String(process.env.SMTP_SECURE).toLowerCase())
+    : port === 465;
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+
+  cachedTransporter = nodemailer.createTransport({
+    host,
+    port,
+    secure,
+    auth: user ? { user, pass: pass || "" } : undefined,
+  });
+  return cachedTransporter;
+}
+
+function sessionKey(userId: string | undefined, email: string): string {
+  return `${userId ? String(userId) : "anon"}::${email.toLowerCase()}`;
+}
+
+function generateCode(len = CODE_LENGTH): string {
+  let code = "";
+  for (let i = 0; i < len; i += 1) {
+    code += Math.floor(Math.random() * 10);
+  }
+  return code;
+}
+
+function resolveFromAddress(): string | null {
+  const explicit = process.env.SMTP_FROM;
+  if (explicit) return explicit;
+
+  const email = process.env.SMTP_USER || process.env.SMTP_FROM_EMAIL;
+  if (!email) return null;
+  const name = process.env.SMTP_FROM_NAME;
+  return name ? `${name} <${email}>` : email;
+}
+
+export async function POST(req: Request) {
+  const transport = buildTransporter();
+  const from = resolveFromAddress();
+  if (!transport || !from) {
+    return NextResponse.json(
+      { ok: false, error: "smtp-not-configured" },
+      { status: 500 }
+    );
+  }
+
+  const body = await req.json().catch(() => ({} as Record<string, unknown>));
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+  const userId = body.userId ? String(body.userId) : undefined;
+  const ttlRaw = Number(body.ttlSeconds ?? DEFAULT_TTL);
+
+  if (!validateEmailFormat(email)) {
+    return NextResponse.json(
+      { ok: false, error: "invalid-email" },
+      { status: 400 }
+    );
+  }
+
+  const ttlSeconds = Math.min(
+    Math.max(Number.isFinite(ttlRaw) ? Math.floor(ttlRaw) : DEFAULT_TTL, MIN_TTL),
+    MAX_TTL
+  );
+
+  const key = sessionKey(userId, email);
+  const now = Date.now();
+  const existing = memdb.emailSessions.get(key);
+  if (existing && now - existing.createdAt < COOLDOWN_MS) {
+    const retryAfter = Math.ceil((COOLDOWN_MS - (now - existing.createdAt)) / 1000);
+    return NextResponse.json(
+      { ok: false, error: "rate-limited", retryAfter },
+      { status: 429 }
+    );
+  }
+
+  const code = generateCode();
+  const expiresAt = now + ttlSeconds * 1000;
+
+  memdb.emailSessions.set(key, {
+    email,
+    code,
+    expiresAt,
+    attempts: 0,
+    userId,
+    createdAt: now,
+  });
+
+  const timeout = setTimeout(() => {
+    const session = memdb.emailSessions.get(key);
+    if (session && session.code === code) {
+      memdb.emailSessions.delete(key);
+    }
+  }, ttlSeconds * 1000);
+  if (typeof (timeout as any).unref === "function") {
+    (timeout as any).unref();
+  }
+
+  const minutes = Math.max(1, Math.round(ttlSeconds / 60));
+  const subject = "Код подтверждения e-mail";
+  const text = `Ваш код подтверждения: ${code}. Он действует ${minutes} мин.`;
+  const html = `<p>Ваш код подтверждения:</p><p style="font-size:24px; letter-spacing:8px;"><strong>${code}</strong></p><p>Срок действия: ${minutes} мин.</p>`;
+
+  try {
+    await transport.sendMail({
+      from,
+      to: email,
+      subject,
+      text,
+      html,
+    });
+  } catch (err) {
+    memdb.emailSessions.delete(key);
+    return NextResponse.json(
+      { ok: false, error: "smtp-error", detail: String(err) },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    expiresAt,
+    resendAfter: Math.ceil(COOLDOWN_MS / 1000),
+    debugCode: EMAIL_DEBUG ? code : undefined,
+  });
+}

--- a/app/email/page.tsx
+++ b/app/email/page.tsx
@@ -4,21 +4,53 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   validateEmailFormat, suggestDomainFor, isDisposableDomain,
-  startVerification, verifyCode, getEmail, splitEmail
+  startVerification, verifyCode, getEmail, splitEmail,
 } from '../../lib/email-util';
+
+type State = {
+  email: string;
+  sent: boolean;
+  error: string;
+  info: string;
+  code: string;
+  isSending: boolean;
+  isVerifying: boolean;
+  expiresAt: number | null;
+};
+
+const CODE_LENGTH = 6;
 
 export default function EmailPage(){
   const router = useRouter();
-  const [{email, sent, demoCode, error, info, code}, set] = useState({
-    email:'', sent:false, demoCode:'', error:'', info:'', code:''
+  const [userId, setUserId] = useState<string>('anon');
+  const [state, setState] = useState<State>({
+    email:'',
+    sent:false,
+    error:'',
+    info:'',
+    code:'',
+    isSending:false,
+    isVerifying:false,
+    expiresAt:null,
   });
 
+  const { email, sent, error, info, code, isSending, isVerifying, expiresAt } = state;
+
   useEffect(()=>{
-    const { email: current } = getEmail();
-    if(current){ 
-      // уже есть e-mail — редактирование
-      set(s=>({...s, email: current!}));
-    }
+    try {
+      const { email: current } = getEmail();
+      if (current) {
+        setState(s => ({ ...s, email: current }));
+      }
+      const storedUser =
+        localStorage.getItem('userId') ||
+        localStorage.getItem('username') ||
+        undefined;
+      if (storedUser) {
+        const normalized = storedUser.replace(/^@/, '').trim();
+        setUserId(normalized || storedUser);
+      }
+    } catch {}
   },[]);
 
   const suggestion = useMemo(()=> email ? suggestDomainFor(email) : null, [email]);
@@ -27,32 +59,95 @@ export default function EmailPage(){
     return domain ? isDisposableDomain(domain) : false;
   }, [email]);
 
-  const onSend = ()=>{
-    const e = email.trim();
-    if(!validateEmailFormat(e)){
-      set(s=>({...s, error:'Введите корректный e-mail', info:''}));
-      return;
+  const expiryLabel = useMemo(()=>{
+    if (!expiresAt) return '';
+    try {
+      return new Date(expiresAt).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    } catch {
+      return '';
     }
-    const {code} = startVerification(e, 600);
-    set(s=>({...s, sent:true, demoCode:code, error:'', info:'Код отправлен (демо). Введите 6 цифр ниже.'}));
+  }, [expiresAt]);
+
+  const setError = (message: string)=>{
+    setState(s => ({ ...s, error: message, info: '' }));
   };
 
-  const onVerify = ()=>{
-    const res = verifyCode(code);
+  const onSend = async ()=>{
+    const trimmed = email.trim();
+    if(!validateEmailFormat(trimmed)){
+      setError('Введите корректный e-mail');
+      return;
+    }
+    setState(s => ({ ...s, isSending:true, error:'', info:'Отправляем код…' }));
+    const res = await startVerification(trimmed, { ttlSeconds: 600, userId });
+    if(!res.ok){
+      const map: Record<string,string> = {
+        'invalid-email':'Введите корректный e-mail',
+        'smtp-not-configured':'SMTP не настроен. Обратитесь к администратору.',
+        'smtp-error':'Не удалось отправить письмо. Попробуйте позже.',
+        'rate-limited': res.retryAfter
+          ? `Код уже отправлен. Повторите через ${res.retryAfter} сек.`
+          : 'Слишком частые запросы. Попробуйте чуть позже.',
+      };
+      const message = map[res.error||''] || 'Не удалось отправить код. Попробуйте позже.';
+      setState(s => ({ ...s, isSending:false, error: message, info:'' }));
+      return;
+    }
+    if (res.debugCode) {
+      console.debug('[email] verification code (debug):', res.debugCode);
+    }
+    const expiryMessage = res.expiresAt
+      ? ` Код действует до ${new Date(res.expiresAt).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}.`
+      : '';
+    setState(s => ({
+      ...s,
+      isSending:false,
+      sent:true,
+      error:'',
+      info:`Код отправлен. Проверьте почту.${expiryMessage}`,
+      expiresAt: res.expiresAt ?? null,
+      code:'',
+    }));
+  };
+
+  const onVerify = async ()=>{
+    const trimmedEmail = email.trim();
+    if(!validateEmailFormat(trimmedEmail)){
+      setError('Введите корректный e-mail');
+      return;
+    }
+    const trimmedCode = code.trim();
+    if(trimmedCode.length !== CODE_LENGTH){
+      setError('Введите 6-значный код из письма');
+      return;
+    }
+    setState(s => ({ ...s, isVerifying:true, error:'', info:'Проверяем код…' }));
+    const res = await verifyCode(trimmedEmail, trimmedCode, { userId });
     if(!res.ok){
       const map: Record<string,string> = {
         'expired':'Срок действия кода истёк. Отправьте ещё раз.',
         'mismatch':'Неверный код. Проверьте и попробуйте снова.',
-        'no-session':'Нет активной сессии подтверждения. Отправьте код заново.'
+        'no-session':'Нет активной сессии подтверждения. Отправьте код заново.',
+        'too-many-attempts':'Превышено число попыток. Запросите новый код.',
+        'invalid-code':'Введите 6-значный код из письма.',
       };
-      set(s=>({...s, error: map[res.reason||'mismatch'] || 'Не удалось подтвердить код'}));
+      let message = map[res.error||''] || 'Не удалось подтвердить код.';
+      if(res.error==='mismatch' && typeof res.attemptsLeft === 'number'){
+        message += ` Осталось попыток: ${res.attemptsLeft}.`;
+      }
+      setState(s => ({ ...s, isVerifying:false, error: message, info:'' }));
       return;
     }
-    // success → назад в профиль
+    const confirmedEmail = res.profile?.email || trimmedEmail;
+    try {
+      localStorage.setItem('userEmail', confirmedEmail);
+      localStorage.setItem('userEmailVerified', '1');
+    } catch {}
+    setState(s => ({ ...s, isVerifying:false, error:'', info:'E-mail подтверждён!' }));
     router.push('/profile' as any);
   };
 
-  const onResend = ()=> onSend();
+  const onResend = ()=>{ if(!isSending) onSend(); };
 
   return (
     <div className="vstack" style={{gap:16}}>
@@ -62,7 +157,15 @@ export default function EmailPage(){
         <label htmlFor="email"><b>E-mail</b></label>
         <input
           id="email" type="email" placeholder="you@example.com" value={email}
-          onChange={e=>set(s=>({...s, email:e.target.value, error:'', info:''}))}
+          onChange={e=>setState(s=>({
+            ...s,
+            email:e.target.value,
+            error:'',
+            info:'',
+            sent:false,
+            code:'',
+            expiresAt:null,
+          }))}
           style={{padding:'12px', border:'1px solid var(--border)', borderRadius:'12px',
                   background:'var(--card)', color:'var(--text)'}}
         />
@@ -78,7 +181,7 @@ export default function EmailPage(){
             </div>
             <button className="btn" onClick={()=>{
               const local = email.split('@')[0] || '';
-              set(s=>({...s, email: `${local}@${suggestion}`}));
+              setState(s=>({ ...s, email: `${local}@${suggestion}`, error:'', info:'', sent:false }));
             }}>Исправить</button>
           </div>
         )}
@@ -96,32 +199,38 @@ export default function EmailPage(){
         )}
 
         {!sent ? (
-          <button className="btn primary" onClick={onSend}>Отправить код</button>
+          <button className="btn primary" onClick={onSend} disabled={isSending}>
+            {isSending ? 'Отправка…' : 'Отправить код'}
+          </button>
         ) : (
           <div className="vstack" style={{gap:8}}>
             <label htmlFor="code"><b>Код из письма</b></label>
             <input
-              id="code" inputMode="numeric" pattern="[0-9]*" maxLength={6} placeholder="6 цифр"
-              value={code} onChange={e=>set(s=>({...s, code:e.target.value.replace(/\D/g,'')}))}
+              id="code" inputMode="numeric" pattern="[0-9]*" maxLength={CODE_LENGTH} placeholder="6 цифр"
+              value={code}
+              onChange={e=>{
+                const digits = e.target.value.replace(/\D/g,'').slice(0, CODE_LENGTH);
+                setState(s=>({ ...s, code:digits, error:'', info:'' }));
+              }}
               style={{padding:'12px', border:'1px solid var(--border)', borderRadius:'12px',
                       letterSpacing:'6px', textAlign:'center', fontSize:18}}
             />
+            {expiryLabel && (
+              <div className="muted" style={{fontSize:12}}>Код действует до {expiryLabel}</div>
+            )}
             <div className="hstack" style={{justifyContent:'space-between'}}>
-              <button className="btn" onClick={onResend}>Отправить ещё раз</button>
-              <button className="btn primary" onClick={onVerify}>Подтвердить</button>
-            </div>
-            <div className="muted" style={{fontSize:12}}>
-              Для демо: код <b>{demoCode}</b> (в реальном приложении он придёт письмом).
+              <button className="btn" onClick={onResend} disabled={isSending}>
+                {isSending ? 'Отправка…' : 'Отправить ещё раз'}
+              </button>
+              <button className="btn primary" onClick={onVerify} disabled={isVerifying || code.length !== CODE_LENGTH}>
+                {isVerifying ? 'Подтверждение…' : 'Подтвердить'}
+              </button>
             </div>
           </div>
         )}
 
         {error && <div className="muted" style={{color:'var(--danger)'}}>{error}</div>}
         {info && !error && <div className="muted">{info}</div>}
-      </div>
-
-      <div className="card muted" style={{fontSize:12}}>
-        Без бэкенда e-mail подтверждается локально. Для реальной отправки писем нужен сервер/SMTP.
       </div>
     </div>
   );

--- a/lib/email-util.ts
+++ b/lib/email-util.ts
@@ -50,44 +50,145 @@ export function suggestDomainFor(email: string): string | null {
   return best ? best.d : null;
 }
 
-function randDigits(len=6): string {
-  let s=''; for(let i=0;i<len;i++) s+=Math.floor(Math.random()*10);
-  return s;
+const API_START = '/api/email/verification/start';
+const API_CONFIRM = '/api/email/verification/confirm';
+
+export type StartVerificationOptions = {
+  ttlSeconds?: number;
+  userId?: string;
+  signal?: AbortSignal;
+};
+
+export type StartVerificationResult = {
+  ok: boolean;
+  expiresAt?: number;
+  resendAfter?: number;
+  debugCode?: string;
+  error?: string;
+  retryAfter?: number;
+};
+
+export async function startVerification(
+  email: string,
+  ttlOrOptions?: number | StartVerificationOptions,
+  maybeOptions?: StartVerificationOptions
+): Promise<StartVerificationResult> {
+  let options: StartVerificationOptions = {};
+  if (typeof ttlOrOptions === 'number') {
+    options = { ...maybeOptions, ttlSeconds: ttlOrOptions };
+  } else if (typeof ttlOrOptions === 'object' && ttlOrOptions) {
+    options = ttlOrOptions;
+  }
+
+  const payload: Record<string, unknown> = { email: email.trim() };
+  if (typeof options.ttlSeconds === 'number') payload.ttlSeconds = options.ttlSeconds;
+  if (options.userId) payload.userId = options.userId;
+
+  try {
+    const res = await fetch(API_START, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: options.signal,
+    });
+    let data: any = null;
+    try {
+      data = await res.json();
+    } catch {}
+    if (!res.ok) {
+      return {
+        ok: false,
+        error: typeof data?.error === 'string' ? data.error : 'server-error',
+        retryAfter:
+          typeof data?.retryAfter === 'number' ? Number(data.retryAfter) : undefined,
+      };
+    }
+    return {
+      ok: true,
+      expiresAt: typeof data?.expiresAt === 'number' ? Number(data.expiresAt) : undefined,
+      resendAfter:
+        typeof data?.resendAfter === 'number' ? Number(data.resendAfter) : undefined,
+      debugCode: typeof data?.debugCode === 'string' ? data.debugCode : undefined,
+    };
+  } catch (err) {
+    return { ok: false, error: 'network-error' };
+  }
+}
+
+export type VerifyCodeOptions = {
+  userId?: string;
+  signal?: AbortSignal;
+};
+
+export type EmailProfile = {
+  email?: string;
+  emailVerified: boolean;
+  verifiedAt?: number;
+};
+
+export type VerifyCodeResult = {
+  ok: boolean;
+  error?: string;
+  attemptsLeft?: number;
+  profile?: EmailProfile;
+};
+
+export async function verifyCode(
+  email: string,
+  code: string,
+  options: VerifyCodeOptions = {}
+): Promise<VerifyCodeResult> {
+  const payload: Record<string, unknown> = {
+    email: email.trim(),
+    code: code.trim(),
+  };
+  if (options.userId) payload.userId = options.userId;
+
+  try {
+    const res = await fetch(API_CONFIRM, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: options.signal,
+    });
+    let data: any = null;
+    try {
+      data = await res.json();
+    } catch {}
+    if (!res.ok) {
+      return {
+        ok: false,
+        error: typeof data?.error === 'string' ? data.error : 'server-error',
+        attemptsLeft:
+          typeof data?.attemptsLeft === 'number'
+            ? Number(data.attemptsLeft)
+            : undefined,
+      };
+    }
+    let profile: EmailProfile | undefined;
+    if (data?.profile && typeof data.profile === 'object') {
+      profile = {
+        email:
+          typeof data.profile.email === 'string'
+            ? data.profile.email
+            : undefined,
+        emailVerified: Boolean(data.profile.emailVerified),
+        verifiedAt:
+          typeof data.profile.verifiedAt === 'number'
+            ? Number(data.profile.verifiedAt)
+            : undefined,
+      };
+    }
+    return { ok: true, profile };
+  } catch (err) {
+    return { ok: false, error: 'network-error' };
+  }
 }
 
 const LS = {
-  pending: 'email.pending',
-  code: 'email.code',
-  exp: 'email.code.exp',
   verified: 'userEmailVerified',
   user: 'userEmail',
 };
-
-export function startVerification(email: string, ttlSeconds=600): {code:string, exp:number} {
-  const code = randDigits(6);
-  const exp = Date.now() + ttlSeconds*1000;
-  localStorage.setItem(LS.pending, email.trim());
-  localStorage.setItem(LS.code, code);
-  localStorage.setItem(LS.exp, String(exp));
-  // В реале код отправили бы письмом. В демо вернём его наружу.
-  return { code, exp };
-}
-
-export function verifyCode(input: string): { ok:boolean; reason?:string } {
-  const code = localStorage.getItem(LS.code);
-  const exp = Number(localStorage.getItem(LS.exp) || 0);
-  const pending = localStorage.getItem(LS.pending) || '';
-  if(!code || !exp || !pending) return { ok:false, reason:'no-session' };
-  if(Date.now() > exp) return { ok:false, reason:'expired' };
-  if(input.trim() !== code) return { ok:false, reason:'mismatch' };
-  // успех: переносим e-mail в «подтверждён»
-  localStorage.setItem(LS.user, pending);
-  localStorage.setItem(LS.verified, '1');
-  localStorage.removeItem(LS.pending);
-  localStorage.removeItem(LS.code);
-  localStorage.removeItem(LS.exp);
-  return { ok:true };
-}
 
 export function getEmail(): { email?:string; verified:boolean } {
   const email = localStorage.getItem(LS.user) || undefined;

--- a/lib/memdb.ts
+++ b/lib/memdb.ts
@@ -1,4 +1,33 @@
-export type Mem = { links: Map<string,string>; levels: Map<string,number>; };
+export type EmailVerificationSession = {
+  email: string;
+  code: string;
+  expiresAt: number;
+  attempts: number;
+  userId?: string;
+  createdAt: number;
+};
+
+export type ProfileRecord = {
+  email?: string;
+  emailVerified: boolean;
+  verifiedAt?: number;
+};
+
+export type Mem = {
+  links: Map<string, string>;
+  levels: Map<string, number>;
+  emailSessions: Map<string, EmailVerificationSession>;
+  profiles: Map<string, ProfileRecord>;
+};
+
 const g = globalThis as any;
-if(!g.__MEMDB__) g.__MEMDB__ = { links:new Map(), levels:new Map() } as Mem;
+if (!g.__MEMDB__) {
+  g.__MEMDB__ = {
+    links: new Map(),
+    levels: new Map(),
+    emailSessions: new Map(),
+    profiles: new Map(),
+  } as Mem;
+}
+
 export const memdb: Mem = g.__MEMDB__;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "html5-qrcode": "^2.3.8",
         "next": "^15.5.2",
         "next-themes": "^0.4.6",
+        "nodemailer": "^7.0.6",
         "qrcode": "^1.5.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -8579,6 +8580,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.3.tgz",
       "integrity": "sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog=="
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.6.tgz",
+      "integrity": "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "html5-qrcode": "^2.3.8",
     "next": "^15.5.2",
     "next-themes": "^0.4.6",
+    "nodemailer": "^7.0.6",
     "qrcode": "^1.5.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- add server routes for starting and confirming email verification with SMTP delivery and TTL handling backed by the in-memory store
- refactor client email verification page to use the new API endpoints, show request states, and sync verified email locally
- document SMTP environment variables and add nodemailer dependency for outbound email support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf2fe538808326be5bb41ec2aa7fb7