### PR TITLE
Wrap TabBar with Suspense for static generation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import './globals.css';
 import Providers from './providers';
-import React from 'react';
+import React, { Suspense } from 'react';
 import TabBar from '../components/ui/TabBar';
 import { Web3Provider } from '../components/providers/Web3';
 
@@ -23,7 +23,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </Providers>
         </Web3Provider>
 
-        <TabBar />
+        <Suspense fallback={null}>
+          <TabBar />
+        </Suspense>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- import `Suspense` from React in the root layout and use it to wrap the `TabBar`
- prepare the router-dependent tab bar to suspend safely during static generation

## Testing
- `npm run build` *(fails: Module not found: Can't resolve 'wagmi')*

------
https://chatgpt.com/codex/tasks/task_e_68cf388ea3d083268bfcde6d37fae6f7