### PR TITLE
Fix typed routes and add profile placeholders

### DIFF
--- a/app/pin/page.tsx
+++ b/app/pin/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 async function sha256Hex(s: string) {
@@ -8,7 +8,7 @@ async function sha256Hex(s: string) {
   return Array.from(new Uint8Array(buf)).map(b=>b.toString(16).padStart(2,'0')).join('');
 }
 
-export default function PinPage(){
+function PinContent(){
   const router = useRouter();
   const params = useSearchParams();
   const mode = (params.get('mode') === 'set') ? 'set' : 'check';
@@ -16,23 +16,21 @@ export default function PinPage(){
 
   useEffect(() => {
     if (pin.length !== 4) return;
-    (async () => {
-      const hash = await sha256Hex(pin);
-      const stored = localStorage.getItem('pinHash');
-      if (mode === 'set') {
-    localStorage.setItem('pinHash', hash);
-        sessionStorage.setItem('unlocked', '1');
-        router.replace('/home');
-      } else {
-        if (stored && stored === hash) {
+      (async () => {
+        const hash = await sha256Hex(pin);
+        const stored = localStorage.getItem('pinHash');
+        if (mode === 'set') {
+          localStorage.setItem('pinHash', hash);
+          sessionStorage.setItem('unlocked', '1');
+          router.replace('/home');
+        } else if (stored && stored === hash) {
           sessionStorage.setItem('unlocked', '1');
           router.replace('/home');
         } else {
           alert('Неверный PIN');
           setPin('');
         }
-      }
-    })();
+      })();
   }, [pin, mode, router]);
 
   const press = (k: string) => {
@@ -63,5 +61,13 @@ export default function PinPage(){
         ))}
       </div>
     </div>
+  );
+}
+
+export default function PinPage(){
+  return (
+    <Suspense fallback={<div style={{minHeight:'100svh', background:'var(--bg)'}}/>}>
+      <PinContent/>
+    </Suspense>
   );
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 import Link from 'next/link';
+import type { Route } from 'next';
 import { useEffect, useMemo, useState } from 'react';
 import { getUser } from '@/lib/tg';
 import TabBar from '@/components/ui/TabBar';
 import { useI18n } from '@/components/providers/I18nProvider';
 import { LANG_LABEL, type Lang } from '@/lib/i18n';
 
-function Row({icon, title, right, href}:{icon:string; title:string; right?:string; href?:string}) {
+function Row({icon, title, right, href}:{icon:string; title:string; right?:string; href?:Route}) {
   const C = (
     <div style={{
       display:'flex', alignItems:'center', gap:12, padding:'14px',
@@ -59,7 +60,7 @@ export default function ProfilePage(){
 
       <div style={{padding:'0 14px'}}>
         <div style={{background:'#fff', border:'1px solid #eee', borderRadius:16, overflow:'hidden'}}>
-          <Row icon="👥" title={t('profile.ref')}    href="/referral" />
+          <Row icon="👥" title={t('profile.ref')}    href="/referrals" />
           <Row icon="🎁" title={t('profile.promos')} href="/promos"  />
         </div>
       </div>

--- a/app/promos/page.tsx
+++ b/app/promos/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useI18n } from '@/components/providers/I18nProvider';
+import TabBar from '@/components/ui/TabBar';
+
+export default function PromosPage(){
+  const { t } = useI18n();
+  return (
+    <div style={{minHeight:'100svh',background:'#f7f8fa',fontFamily:'system-ui',display:'flex',flexDirection:'column'}}>
+      <div style={{position:'sticky',top:0,background:'#fff',borderBottom:'1px solid #eee',padding:'12px 14px',fontWeight:800}}>
+        {t('profile.promos')}
+      </div>
+
+      <div style={{padding:16,color:'#6b7280'}}>
+        <p style={{margin:0}}>{t('profile.promos')} — {t('soon')}.</p>
+      </div>
+
+      <div style={{flexGrow:1}}/>
+      <TabBar current="profile" />
+    </div>
+  );
+}

--- a/app/settings/devices/page.tsx
+++ b/app/settings/devices/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useI18n } from '@/components/providers/I18nProvider';
+import TabBar from '@/components/ui/TabBar';
+
+export default function DevicesPage(){
+  const { t } = useI18n();
+  return (
+    <div style={{minHeight:'100svh',background:'#f7f8fa',fontFamily:'system-ui',display:'flex',flexDirection:'column'}}>
+      <div style={{position:'sticky',top:0,background:'#fff',borderBottom:'1px solid #eee',padding:'12px 14px',fontWeight:800}}>
+        {t('profile.devices')}
+      </div>
+
+      <div style={{padding:16,color:'#6b7280'}}>
+        <p style={{margin:0}}>{t('profile.devices')} — {t('soon')}.</p>
+      </div>
+
+      <div style={{flexGrow:1}}/>
+      <TabBar current="profile" />
+    </div>
+  );
+}

--- a/app/settings/security/page.tsx
+++ b/app/settings/security/page.tsx
@@ -9,8 +9,8 @@ function Section({title}:{title:string}) {
 
 export default function SecurityPage(){
   const { t } = useI18n();
-  const [pin, setPin] = useState(localStorage.getItem('pinHash') ? true : false);
-  const [hide, setHide] = useState(localStorage.getItem('hideBalance') === '1');
+  const [pin, setPin] = useState(() => (typeof window !== 'undefined' && localStorage.getItem('pinHash') ? true : false));
+  const [hide, setHide] = useState(() => (typeof window !== 'undefined' && localStorage.getItem('hideBalance') === '1'));
 
   useEffect(()=>{},[]);
 

--- a/components/providers/I18nProvider.tsx
+++ b/components/providers/I18nProvider.tsx
@@ -1,28 +1,25 @@
 'use client';
-import {createContext, useContext, useEffect, useMemo, useState} from 'react';
-
-export type Lang = 'ru'|'en'|'id'|'es'|'de';
+import {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
+import { FLAGS, LANG_LABEL, translate, type Lang } from '@/lib/i18n';
 
 type Ctx = {
   lang: Lang;
   setLang: (l:Lang)=>void;
   t: (k:string)=>string;
+  label: (l:Lang)=>string;
+  flag: (l:Lang)=>string;
 };
 const I18nContext = createContext<Ctx | null>(null);
-
-const DICT: Record<Lang, Record<string,string>> = {
-  en: { 'profile.title':'Profile' },
-  ru: { 'profile.title':'Профиль' },
-  id: {}, es: {}, de: {}
-};
 
 export default function I18nProvider({children}:{children:React.ReactNode}) {
   const [lang, setLang] = useState<Lang>('en');
   useEffect(() => {
     try { const s = localStorage.getItem('lang') as Lang | null; if (s) setLang(s); } catch {}
   }, []);
-  const t = (k:string) => (DICT[lang]?.[k] ?? k);
-  const value = useMemo(()=>({lang, setLang, t}),[lang]);
+  const t = useCallback((k:string) => translate(lang, k), [lang]);
+  const label = useCallback((l:Lang) => LANG_LABEL[l] ?? l, []);
+  const flag = useCallback((l:Lang) => FLAGS[l] ?? '', []);
+  const value = useMemo(()=>({lang, setLang, t, label, flag}),[lang, t, label, flag]);
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
 }
 

--- a/components/ui/TabBar.tsx
+++ b/components/ui/TabBar.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Link from 'next/link';
+import type { Route } from 'next';
 import { usePathname } from 'next/navigation';
 import { useI18n } from '@/components/providers/I18nProvider';
 
@@ -11,7 +12,7 @@ export default function TabBar({current}:{current?:'home'|'history'|'scan'|'inve
                : pathname.startsWith('/invest') ? 'invest'
                : pathname === '/scan' ? 'scan' : 'home');
 
-  const Item = ({href, label, active}:{href:string; label:string; active:boolean}) => (
+  const Item = ({href, label, active}:{href:Route; label:string; active:boolean}) => (
     <Link href={href} style={{
       flex:1, textAlign:'center', textDecoration:'none',
       color: active ? '#0b1628' : '#7e8a9d', fontWeight: active ? 700 : 600


### PR DESCRIPTION
## Summary
- fix profile link typing by adopting Next.js Route types, correct the referrals href, and update the tab bar
- add translated placeholder screens for promos and settings/devices while improving the i18n provider helpers
- wrap the PIN page in suspense and guard localStorage access in security settings to satisfy the production build

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d41510f2d0832683641c430129f201